### PR TITLE
fix date in pass description

### DIFF
--- a/templates/sweetcorn/passes.html
+++ b/templates/sweetcorn/passes.html
@@ -50,7 +50,7 @@
 		</p>
 		<h2 class="text-bf fs-400"> This pass includes: </h2>
 		<ul>
-			<li> Advanced Lindy Hop Classes on Saturday </li>
+			<li> Advanced Lindy Hop Classes on Friday </li>
 			<li> All-Levels Solo Jazz Class on Saturday </li>
 			<li> All dances from Friday to Sunday </li>
 		</ul>
@@ -66,7 +66,7 @@
 		</p>
 		<h2 class="text-bf fs-400"> This pass includes: </h2>
 		<ul>
-			<li> Advanced Lindy Hop Classes on Saturday </li>
+			<li> Advanced Lindy Hop Classes on Friday </li>
 			<li> All-Levels Solo Jazz Class on Saturday </li>
 			<li> Intermediate Lindy Hop Classes on Saturday </li>
 			<li> All dances from Friday to Sunday </li>


### PR DESCRIPTION
The passes section of the website incorrectly states that the advanced lindy hop class is on Saturday. The schedule itself seems to be fine.
