### PR TITLE
Make landing page for sweetcorn swingout 2026

### DIFF
--- a/templates/sweetcorn/index.html
+++ b/templates/sweetcorn/index.html
@@ -11,14 +11,6 @@
 	<body>
 		<header class="center main-header">
 			<img class="logo" src="{{assets['assets/sweetcorn/logo.svg'].absolute_path}}">
-			<nav class="main-nav">
-				<ul class="nav-list ff-primary-heading color-primary fs-700">
-					<li><a class="nav-link" href="#schedule">Schedule</a><li>
-					<li><a class="nav-link" href="#passes">Passes</a><li>
-					<li><a class="nav-link" href="#instructors">Instructors</a><li>
-					<li><a class="nav-link" href="#local-guide">Local Guide</a><li>
-				</ul>
-			</nav>
 		</header>
 		<main class="center">
 			<div class="breakout banner">

--- a/templates/sweetcorn/index.html
+++ b/templates/sweetcorn/index.html
@@ -23,7 +23,6 @@
 		<main class="center">
 			<div class="breakout banner">
 				{{ assets['sweetcorn/banner'].tag(class="banner-img") }}
-				<a href="https://forms.gle/tzodvp2nEns65dLU6" class="button banner-btn fs-700"> Register Now! </a>
 			</div>
 			<div class="content columns-3">
 				<div>

--- a/templates/sweetcorn/index.html
+++ b/templates/sweetcorn/index.html
@@ -19,15 +19,13 @@
 			<div class="content columns-3">
 				<div>
 					<h1 class="center-text ff-primary-heading call-out"> Iowa City, Iowa <br> July 3-5, 2026</h1>
-					<p class="color-primary text-bf">
+				</div>
+				<div class="span-2 fs-500 gaps color-primary text-bf">
+					<p>
+
 						Shuck off your inhibitions, crop dust off your dancing shoes, and
 						meet us on the dance floor for Iowa City's Sweet Corn Swingout!
-					</p>
-				</div>
-				<div class="span-2 fs-500 gaps">
-					<p>
-						Join us in Iowa City for a weekend of Lindy Hop classes, live
-						music, and dancing! The seeds are still being sown. Check back
+						The seeds are still being sown. Check back
 						after a spring rain for more details!
 					</p>
 				</div>

--- a/templates/sweetcorn/index.html
+++ b/templates/sweetcorn/index.html
@@ -26,7 +26,7 @@
 			</div>
 			<div class="content columns-3">
 				<div>
-					<h1 class="center-text ff-primary-heading call-out"> Iowa City, Iowa July 4-6</h1>
+					<h1 class="center-text ff-primary-heading call-out"> Iowa City, Iowa <br> July 3-5, 2026</h1>
 					<p class="color-primary text-bf">
 						Shuck off your inhibitions, crop dust off your dancing shoes, and
 						meet us on the dance floor for Iowa City's Sweet Corn Swingout!

--- a/templates/sweetcorn/index.html
+++ b/templates/sweetcorn/index.html
@@ -41,18 +41,6 @@
 				</div>
 			</div>
 
-			{% include 'sweetcorn/schedule.html' %}
-			{% include 'sweetcorn/passes.html' %}
-
-			<div class="content columns-3">
-				<div class="span-3 center stack">
-					<a href="https://forms.gle/tzodvp2nEns65dLU6" class="button stacked fs-700"> Register Now! </a>
-				</div>
-			</div>
-
-			{% include 'sweetcorn/instructors.html' %}
-			{% include 'sweetcorn/local-guide.html' %}
-
 		</main>
 		<footer class="main-footer center fs-200">
 

--- a/templates/sweetcorn/index.html
+++ b/templates/sweetcorn/index.html
@@ -35,21 +35,8 @@
 				<div class="span-2 fs-500 gaps">
 					<p>
 						Join us in Iowa City for a weekend of Lindy Hop classes, live
-						music, and dancing! Shannon Lea Watkins and Kevin Weng will share
-						kernels of wisdom to take your Lindy Hop dancing to the next level.
-						There will be three dances, including a live band on Saturday night
-						where the rhythms of <a
-							href="https://www.sweetieandthetoothaches.com/">Sweetie and the
-							Toothaches</a> will get you hot & buttered. 
-					</p>
-					<p>
-					The <a
-						href="https://summerofthearts.org/festival/2025-iowa-city-jazz-festival/">Iowa
-						City Jazz Festival</a> is happening at the same time and mere
-					blocks away from our programming! In between classes and dances, you
-					can meander the streets of Iowa City, enjoying street food, artist
-					booths, and live jazz of all varieties. We may even take our dancing
-					to the streets!
+						music, and dancing! The seeds are still being sown. Check back
+						after a spring rain for more details!
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
Sweetcorn swingout 2026 is coming but we still have the details for 2025 up. This aims to remedy that.

Updated the dates on the sweetcorn swingout page, removed all other specific details, and added  a puny check later note.