### PR TITLE
add information to local guide

### DIFF
--- a/templates/sweetcorn/local-guide.html
+++ b/templates/sweetcorn/local-guide.html
@@ -68,8 +68,10 @@
 		<p>Saturday Blues Dance</p>
 		<h2 class="text-bf">Parking:</h2>
 		<p>Free street parking (meters not enforced).</p>
+	</section>
 
-		<hgroup style="margin-top: 40px">
+	<section class="card">
+		<hgroup>
 			<h1 class="text-bf"><a href="https://maps.app.goo.gl/SZengsptV2RHtjcH8">The Green House</a></h1>
 			<p>505 E Washington St.</p>
 		</hgroup>

--- a/templates/sweetcorn/local-guide.html
+++ b/templates/sweetcorn/local-guide.html
@@ -72,7 +72,7 @@
 
 	<section class="card">
 		<hgroup>
-			<h1 class="text-bf"><a href="https://maps.app.goo.gl/SZengsptV2RHtjcH8">The Green House</a></h1>
+			<h1 class="text-bf"><a href="https://www.thegreenhouseic.com/">The Green House</a></h1>
 			<p>505 E Washington St.</p>
 		</hgroup>
 		<h2 class="text-bf">Events:</h2>

--- a/templates/sweetcorn/local-guide.html
+++ b/templates/sweetcorn/local-guide.html
@@ -38,6 +38,12 @@
 			east of venue on E College Street. However, with the Jazz Fest in
 			town, plan extra time to find free parking.
 		</p>
+		<h2 class="text-bf">Info:</h2>
+		<ul>
+			<li>Vinyl floors</li>
+			<li>Accessible by ramp and elevator</li>
+			<li>Bathrooms on same floor</li>
+		</ul>
 	</section>
 	<section class="card">
 		<hgroup>
@@ -52,14 +58,20 @@
 			<a href="https://transportation.uiowa.edu/parking/facilities/north-campus-ramp">North Campus Ramp</a>
 		</p>
 		<p>
-
 			After 6 p.m., the street metered
 			parking and the Chauncey Swan Ramp
 			(a 10-minute walk away) are both free.
 			However, with the Jazz Fest in town,
 			plan extra time to find free parking.
 		</p>
+		<h2 class="text-bf">Info:</h2>
+		<ul>
+			<li>Wood floors</li>
+			<li>Accessible by ramp</li>
+			<li>Bathrooms on same floor</li>
+		</ul>
 	</section>
+
 	<section class="card">
 		<hgroup>
 			<h1 class="text-bf"><a href="https://sanghaic.com/#find-us">Brewery Square (sangha)</a></h1>
@@ -68,6 +80,12 @@
 		<p>Saturday Blues Dance</p>
 		<h2 class="text-bf">Parking:</h2>
 		<p>Free street parking (meters not enforced).</p>
+		<h2 class="text-bf">Info:</h2>
+		<ul>
+			<li>Wood floors</li>
+			<li>Accessible by stairs</li>
+			<li>Bathrooms up more stairs</li>
+		</ul>
 	</section>
 
 	<section class="card">
@@ -85,6 +103,12 @@
 				href="https://www.icgov.org/government/departments-and-divisions/transportation/parking/parking-ramps-parking-meters">Chauncey
 			Swan Ramp</a> (right next door) are free!
 		</p>
+		<h2 class="text-bf">Info:</h2>
+		<ul>
+			<li>Smooth concrete floors</li>
+			<li>Ground floor entry</li>
+			<li>Bathrooms on same floor</li>
+		</ul>
 	</section>
 </section>
 <section class="content columns-2">


### PR DESCRIPTION
This pr adds information to the local guide section so each location has some physical details about the space. There are screenshots at the bottom showing what these changes look like on my machine.

There are two minor changes rolled into this pr. One makes the green house its own section so it gets a little corn icon and fixes some odd spacing issue. The other links to the green houses official webpage instead of its google maps entry. Feel free to remove those commits if either of those were intentional.

## Screenshots
<details><summary>Profile screenshot</summary>
<img width="1080" height="1920" alt="local_guide_profile" src="https://github.com/user-attachments/assets/413aef2c-8379-4733-afc7-edee20e2ea41" />
</details> 
<details><summary>Landscape screenshot</summary>
<img width="1078" height="744" alt="local_guide_landscape" src="https://github.com/user-attachments/assets/12a86e02-26e8-47c0-b7f8-11e5a80a584c" />
</details> 

