### PR TITLE
Sweet corn fixes

### DIFF
--- a/templates/sweetcorn/index.html
+++ b/templates/sweetcorn/index.html
@@ -42,7 +42,7 @@
 						href="https://showboatjazzcollective.com/">Showboat Jazz
 						Collective</a> play for the Saturday night dance! You butter believe
 						this band has poppin’ hot tunes.. This year’s kernels of wisdom to take
-						your dancing to the next level will come from Phil Attoh-Okine, Shannon
+						your dancing to the next level will come from Nii Attoh Okine, Shannon
 						Lea Watkins, and Javi Javier.  You can look forward to lessons for
 						advanced to beginner dancers, a late-night blues dance, a House dance
 						class for lindy hoppers, and probably some sweet corn.

--- a/templates/sweetcorn/index.html
+++ b/templates/sweetcorn/index.html
@@ -16,6 +16,7 @@
 					<li><a class="nav-link" href="#schedule">Schedule</a><li>
 					<li><a class="nav-link" href="#passes">Passes</a><li>
 					<li><a class="nav-link" href="#instructors">Instructors</a><li>
+					<li><a class="nav-link" href="#local-guide">Local Guide</a><li>
 				</ul>
 			</nav>
 		</header>

--- a/templates/sweetcorn/index.html
+++ b/templates/sweetcorn/index.html
@@ -42,10 +42,11 @@
 						href="https://showboatjazzcollective.com/">Showboat Jazz
 						Collective</a> play for the Saturday night dance! You butter believe
 						this band has poppin’ hot tunes.. This year’s kernels of wisdom to take
-						your dancing to the next level will come from Nii Attoh Okine, Shannon
-						Lea Watkins, and Javi Javier.  You can look forward to lessons for
-						advanced to beginner dancers, a late-night blues dance, a House dance
-						class for lindy hoppers, and probably some sweet corn.
+						your dancing to the next level will come from Nii Attoh Okine,
+						Shannon Lea Watkins, Nicole Frydman, Alina Lusebrink, and Javi
+						Javier.  You can look forward to lessons for advanced to beginner
+						dancers, a late-night blues dance, a House dance class for lindy
+						hoppers, and probably some sweet corn.
 					</p>
 					<p>
 					The <a

--- a/templates/sweetcorn/instructors.html
+++ b/templates/sweetcorn/instructors.html
@@ -14,7 +14,7 @@
 	<hgroup class="ff-primary-heading center-text span-3">
 		<h1 class="fs-700"> Instructors </h1>
 	</hgroup>
-	{% call instructor("Nii (Phil) Attoh-Okine (he/him)", "sweetcorn/nii_profile") %}
+	{% call instructor("Nii Attoh Okine (he/him)", "sweetcorn/nii_profile") %}
 			is an avid
 			Lindy Hop dancer, competitor, and DJ
 			from Baltimore, Maryland. Over the

--- a/templates/sweetcorn/instructors.html
+++ b/templates/sweetcorn/instructors.html
@@ -83,7 +83,7 @@
  			Photo credit: Mila Moore Photograph
 	{% endcall %}
 
-	{% call instructor("Nicole Frydman (she/her)", "sweetcorn/nicole_profile") %}
+	{% call instructor("Nicole Frydman (she/they)", "sweetcorn/nicole_profile") %}
 			has been dancing
 			a variety of styles of dance for 46 years,
 			dancing swing for 29 years, and teaching

--- a/templates/sweetcorn/schedule.html
+++ b/templates/sweetcorn/schedule.html
@@ -31,7 +31,7 @@
 		{% call day("Friday") %}
 			{{ event(
 					name = "Advanced Lindy Hop Classes",
-					desc = "Instructors: Phil Attoh-Okine and Shannon Lea Watkins",
+					desc = "Instructors: Nii Attoh Okine and Shannon Lea Watkins",
 					location = "Masonic Lodge Event Space: 312 E College St.",
 					time = "Friday, 5–6:40 p.m.",
 				)
@@ -54,7 +54,7 @@
 			}}
 			{{ event(
 					name = "Intermediate Lindy Hop Classes",
-					desc = "Instructors: Phil Attoh-Okine and Shannon Lea Watkins",
+					desc = "Instructors: Nii Attoh Okine and Shannon Lea Watkins",
 					location = "Masonic Lodge Event Space: 312 E College St.",
 					time = "Saturday, 1–4:30 p.m.",
 				)

--- a/templates/sweetcorn/schedule.html
+++ b/templates/sweetcorn/schedule.html
@@ -62,7 +62,7 @@
 			{{ event(
 					name="Beginner Lindy Hop Classes",
 					desc= "Instructors: Alina Lusebrink and Nicole Frydman",
-					location = "TBA",
+					location = "Brewery Square (sangha): 123 North Linn Street | Suite 2F",
 					time = "Saturday, 2:15-4:30 p.m.",
 				)
 			}}

--- a/templates/sweetcorn/schedule.html
+++ b/templates/sweetcorn/schedule.html
@@ -1,4 +1,4 @@
-{% macro event(name, desc, location, time, note, img) -%}
+{% macro event(name, desc, location, time, note, img, rain_location) -%}
 <div>
 	<h1 class="text-bf">{{name}}</h1>
 	{% if desc %}
@@ -6,6 +6,9 @@
 	{% endif %}
 	{% if location %}
 		<p>{{location}}</p>
+	{% endif %}
+	{% if rain_location %}
+		<p><span class="text-bf">Rain Location:</span> {{rain_location}}</p>
 	{% endif %}
 	{% if time %}
 		<p>{{time}}</p>
@@ -40,6 +43,7 @@
 					name = "Lindy in the Streets",
 					desc = "Hit the streets of Jazz Festival with Dj'd dancing, food, drinks and live music",
 					location = "Corner of N. Linn St. and E. Market St.",
+					rain_location = "Masonic Lodge: 312 E College St.",
 					time = "Friday, 7-9:30p.m.",
 				)
 			}}

--- a/templates/sweetcorn/schedule.html
+++ b/templates/sweetcorn/schedule.html
@@ -5,13 +5,13 @@
 		<p>{{desc}}</p>
 	{% endif %}
 	{% if location %}
-		<p>{{location}}</p>
+		<p>📍 {{location}}</p>
 	{% endif %}
 	{% if rain_location %}
-		<p><span class="text-bf">Rain Location:</span> {{rain_location}}</p>
+		<p>📍 <span class="text-bf">Rain Location:</span> {{rain_location}}</p>
 	{% endif %}
 	{% if time %}
-		<p>{{time}}</p>
+		<p>🕙 {{time}}</p>
 	{% endif %}
 	{% if note %}
 		<p class="fs-200">{{note}}</p>


### PR DESCRIPTION
A pile of fixes for the sweet corn swingout page:

- adds local guide to the nav bar
- spells Nii's name as requested
- make the blurb reference all the teachers
- corrects Nicole Frydman's pronouns
- add a location to beginner lindy hop class
- add a rain location to lindy in the street


Beyond informational changes some stylistic markers were added to delineate location and time information. I'm not actually sure why we weren't already doing this as it is in the mockup. With multiple locations this felt crucial:

before

<img width="479" height="157" alt="image" src="https://github.com/user-attachments/assets/c09f5533-75f0-442b-8c51-9454cb588a27" />

after

<img width="466" height="152" alt="image" src="https://github.com/user-attachments/assets/30b703e4-54a2-4e4f-a0d2-09e9486bf73d" />